### PR TITLE
Update to rocket_ws v0.1.1

### DIFF
--- a/examples/websocket/Cargo.toml
+++ b/examples/websocket/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 
 [dependencies]
 rocket = { version = "=0.5.1", default-features = false, features = [ "json" ] }
-rocket_ws = "0.1.0"
+rocket_ws = "0.1.1"
 rocket_okapi = { path = "../../rocket-okapi", features = [ "swagger", "rapidoc", "rocket_ws" ] }
 serde = "1.0"

--- a/rocket-okapi/Cargo.toml
+++ b/rocket-okapi/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4"
 rocket_dyn_templates = { version = "=0.1.0", optional = true }
 rocket_db_pools = { version = "=0.1.0", optional = true }
 rocket_sync_db_pools = { version = "=0.1.0", optional = true }
-rocket_ws = { version = "=0.1.0", optional = true }
+rocket_ws = { version = "=0.1.1", optional = true }
 
 [dev-dependencies]
 rocket_sync_db_pools = { version = "0.1.0", features = [ "diesel_sqlite_pool" ] }


### PR DESCRIPTION
Tests pass, the websocket example builds. [Rocket 0.5.1 release](https://github.com/rwf2/Rocket/blob/master/CHANGELOG.md) includes `rocket_ws` 0.1.1, so I figure this should be a part of this update.